### PR TITLE
Fix post gen hook.

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -26,23 +26,32 @@ web_name={{cookiecutter.project_name}}_web
 web_folder=apps/${web_name}
 web_folder_web=${web_folder}/lib/${web_name}
 
-sed -i -e "/import_config/s/^/# /" $web_folder'/config/prod.exs'
+sed -i '' -e "/import_config/s/^/# /" $web_folder'/config/prod.exs'
 
 db_url='config :{{ cookiecutter.project_name }}, {{ cookiecutter.phoenix_module_name }}.Repo, url: System.get_env("DATABASE_URL"), pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"), ssl: true'
-sed -i -e "/import_config/s/^/${db_url}\\$nl# /" $core_folder'/config/prod.exs'
+sed -i '' -e "/import_config/s/^/${db_url}\\$nl# /" $core_folder'/config/prod.exs'
 
 case '{{cookiecutter.phoenix_auth}}' in
      'Ueberauth')
          config='config :ueberauth, Ueberauth, providers: [identity: {Ueberauth.Strategy.Identity, [callback_methods: ["POST"]]}]'
-         sed -i -e "/^# Import/s/^/\\$config\\$nl/" $web_folder'/config/config.exs'
+         sed -i '' -e "/^# Import/s/^/\\$config\\$nl/" $web_folder'/config/config.exs'
 
-         routes='scope "/auth", {{ cookiecutter.phoenix_module_name }} do pipe_through :browser get "/:provider", AuthController, :request get "/:provider/callback", AuthController, :callback post "/:provider/callback", AuthController, :callback delete "/logout", AuthController, :delete end'
-         sed -i -e "/use.*:router/s/$/\\${nl}require Ueberauth/" $web_folder_web'/router.ex'
-         sed -i -e "/^end/s~^~\\$routes\\$nl~" $web_folder_web'/router.ex'
+         routes='scope "/auth", {{ cookiecutter.phoenix_module_name }} do \
+         pipe_through :browser \
+         get "/:provider", AuthController, :request \
+         get "/:provider/callback", AuthController, :callback \
+         post "/:provider/callback", AuthController, :callback \
+         delete "/logout", AuthController, :delete \
+       end'
+         sed -i '' -e "/use.*:router/s/$/\\${nl}require Ueberauth/" $web_folder_web'/router.ex'
+         sed -i '' -e "/^end/s~^~\\$routes\\$nl~" $web_folder_web'/router.ex'
 
          pkgs='{:ueberauth, "~> 0.6"}, {:ueberauth_identity, "~> 0.2"},'
-         sed -i -e "/extra_applications/s/\]$/, :ueberauth, :ueberauth_identity]/" $web_folder'/mix.exs'
-         sed -i -e "/plug_cowboy/s/^/${pkgs}\\${nl}/" $web_folder'/mix.exs'
+         sed -i '' -e "/extra_applications/s/\]$/, :ueberauth, :ueberauth_identity]/" $web_folder'/mix.exs'
+         sed -i '' -e "/plug_cowboy/s/^/${pkgs}\\${nl}/" $web_folder'/mix.exs'
+
+         mix deps.get
+         mix format
          ;;
      *)
          rm lib/{{cookiecutter.project_name}}_web/controllers/auth_controller.ex


### PR DESCRIPTION
Why:

* Our sed commands were generating backup files.
* Router elixir code wasn't valid elixir.

This change addresses the need by:

* Add empty string as argument backup file ext to `-i` sed flag.
* Add required newlines to router elixir code addition.
* Run mix deps.get and format if we edit elixir code.

Side effects:

* Empty string value to `-i` sed flag may only work on bsd sed, mac uses
  bsd based sed.