### PR TITLE
Make heroku deploy optional.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,8 +5,8 @@
   "erlang_version": "21.2.5",
   "nodejs_version": "10.15.3",
   "phoenix_version": "1.4.2",
-  "deploy_to": "heroku",
-  "heroku_app_name": "{{ cookiecutter.project_name.replace('_', '-') }}",
+  "deploy_to": ["heroku", "None"],
   "phoenix_auth": ["Ueberauth", "None"],
+  "heroku_app_name": "{{ cookiecutter.project_name.replace('_', '-') }}",
   "phoenix_module_name": "{{cookiecutter.project_name.split('_') | map('capitalize') | join()}}"
 }

--- a/hooks/pre_gen_project.sh
+++ b/hooks/pre_gen_project.sh
@@ -15,3 +15,16 @@ if [ "$status" -ne "0" ]; then
   exit 1
 fi
 {% endif %}
+
+cat <<EOF > .tool-versions
+elixir {{cookiecutter.elixir_version}}
+erlang {{cookiecutter.erlang_version}}
+nodejs {{cookiecutter.nodejs_version}}
+EOF
+
+asdf install
+
+mix archive.install hex phx_new {{cookiecutter.phoenix_version}}
+
+# Generate Umbrella app
+mix phx.new {{cookiecutter.project_name}} --umbrella

--- a/{{cookiecutter.project_name}}_umbrella/.tool-versions
+++ b/{{cookiecutter.project_name}}_umbrella/.tool-versions
@@ -1,3 +1,0 @@
-elixir {{cookiecutter.elixir_version}}
-erlang {{cookiecutter.erlang_version}}
-nodejs {{cookiecutter.nodejs_version}}


### PR DESCRIPTION
Why:

* Not all projects will be hosted on heroku.

This change addresses the need by:

* Move phoenix generation to the pre script.
* Move asdf tool versions file generation to the pre script.
* Reorder cookiecutter.json to group required, optional, list, then
  generated options together.
* Fix auth cleanup if turned off.
* Cleanup heroku files if turned off.
* Customize todo list at end of post script depending on cookiecutter
  options chosen.